### PR TITLE
update UglifyJS

### DIFF
--- a/lasso-minify-js-plugin.js
+++ b/lasso-minify-js-plugin.js
@@ -1,20 +1,10 @@
-var parser = require("uglify-js").parser;
-var uglify = require("uglify-js").uglify;
+var UglifyJS = require("uglify-js");
 
 function minify(src, options) {
-    if (!options) {
-        options = {};
-    }
+    options = options || {};
+    options.fromString = true;
 
-    var ast = parser.parse(src, options.strict_semicolons === true);
-
-    if (options.lift_variables === true) {
-        ast = uglify.ast_lift_variables(ast);
-    }
-
-    ast = uglify.ast_mangle(ast, options);
-    ast = uglify.ast_squeeze(ast, options);
-    return uglify.gen_code(ast);
+    return UglifyJS.minify(src, options).code;
 }
 
 module.exports = function (lasso, pluginConfig) {
@@ -27,7 +17,7 @@ module.exports = function (lasso, pluginConfig) {
 
         transform: function(code, lassoContext) {
             try {
-                var minified = minify(code);
+                var minified = minify(code, pluginConfig);
                 if (minified.length && !minified.endsWith(";")) {
                     minified += ";";
                 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     ],
     "maintainers": "Patrick Steele-Idem <pnidem@gmail.com>",
     "dependencies": {
-        "uglify-js": "1.3.x"
+        "uglify-js": "~2.5.0"
     },
     "devDependencies": {
         "mocha": "~1.15.1",


### PR DESCRIPTION
Updated to UglifyJS2 according to their "simple" javascript api https://github.com/mishoo/UglifyJS2#the-simple-way. It didn't look like we needed to do any ast transforming, and the previous setup was just how the api worked in earlier versions. I tested basic usage and error handling.
